### PR TITLE
fix: upgrade rust bridge because bdk_flutter needs higher

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 dependencies: 
   fimber: ^0.7.0
   ffi: ^2.0.2
-  flutter_rust_bridge: 1.75.2
+  flutter_rust_bridge: 1.78.0
   freezed: ^2.3.5
   freezed_annotation: ^2.2.0
   rxdart: ^0.27.7


### PR DESCRIPTION
I use `bdk_flutter` in my app and when trying to integrate breez, I can't get past the error in the version number. So this needs to be upgraded if users have updated version of `bdk_flutter`. 

Error while versioning
_Resolving dependencies...
Because every version of breez_sdk from git depends on flutter_rust_bridge 1.75.2 and every version of bdk_flutter from git depends on flutter_rust_bridge >1.77.1 <=1.78.0, breez_sdk from git is incompatible with bdk_flutter from git.
So, because coinwallet depends on both bdk_flutter from git and breez_sdk from git, version solving failed._