### PR TITLE
Setup automated publishing to pub.dev

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,29 @@
+# The recommended way to publish on pub.dev is via
+# their automated publishing feature.
+# This requires the GitHub action that publishes to pub.dev
+# to be triggered by a Git tag being pushed.
+# The Git tag for releases in this repo is created and pushed automatically
+# in the main repo's publis-flutter workflow.
+# See: https://dart.dev/tools/pub/automated-publishing
+
+name: Publish to pub.dev
+
+on:
+  push:
+    tags:
+    - 'v[0-9]+.[0-9]+.[0-9]+*'
+
+jobs:
+  publish:
+    permissions:
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dart-lang/setup-dart@v1 # GitHub authenticates to pub.dev via OIDC in this step
+      - name: Install dependencies
+        run: dart pub get
+      - name: Dry run
+        run: dart pub publish --dry-run --skip-validation
+      - name: Publish
+        run: dart pub publish --force

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -380,7 +380,7 @@ packages:
     source: hosted
     version: "0.5.0"
   meta:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: meta
       sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
@@ -601,7 +601,7 @@ packages:
     source: hosted
     version: "1.3.2"
   uuid:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: uuid
       sha256: "22c94e5ad1e75f9934b766b53c742572ee2677c56bc871d850a57dad0f82127f"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: breez_sdk
-description: A new flutter plugin project.
+description: Flutter bindings for the Breez SDK
+repository: https://github.com/breez/breez-sdk-flutter
 version: 0.2.15
-publish_to: none
 
 environment:
   sdk: '>=3.0.0 <4.0.0'
@@ -17,6 +17,8 @@ dependencies:
   freezed_annotation: ^2.4.1
   ###
   rxdart: ^0.27.7
+  meta: ^1.10.0
+  uuid: ^4.2.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Sets up publishing to pub.dev. There’s two ways to achieve this:

1. The recommended way: Using their [automated publishing feature](https://dart.dev/tools/pub/automated-publishing). This makes GitHub authenticate to [pub.dev](http://pub.dev/) via OIDC and requires no tokens to be set via GitHub secretes. The drawback is that it only works if the GitHub action that does the publishing is triggered by a Git tag being pushed.
2. Via CLI which [requires some custom magic](https://birju.dev/posts/publish-your-flutter-package-using-github-actions/) and setting a token via GitHub secrets.

Option 1 is what is implemented here. Its benefits/drawbacks are:

➕ Minimal configuration effort
➕ Recommended by pub.dev
➕ No manual steps besides running the `publish-flutter` action in the main repo
➖ The GitHub Action needs to live in this repo and cannot be setup in the main repo

The benefits of option 2 would fit nicer into our setup of having all CI configuration in the main repo:

➕ Could be setup right in the `publish-flutter` action in the main repo
➕ No manual steps besides running the `publish-flutter` action in the main repo
➖ Undocumented (potentially hacky) way of doing it

Happy to hear feedback. I couldn't try out the action and auto-publishing feature yet. I think we will have to wait for the next release to see if it will work. I did, however, manually push the 0.2.15 release which can be found here: https://pub.dev/packages/breez_sdk