### PR TITLE
Install flutter in publishing step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,6 @@ jobs:
       - uses: flutter-actions/setup-flutter@v2
         with:
           channel: stable
-          version: 3.19.0
       - name: Install dependencies
         run: dart pub get
       - name: Publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@
 # This requires the GitHub action that publishes to pub.dev
 # to be triggered by a Git tag being pushed.
 # The Git tag for releases in this repo is created and pushed automatically
-# in the main repo's publis-flutter workflow.
+# in the main repo's publish-flutter workflow.
 # See: https://dart.dev/tools/pub/automated-publishing
 
 name: Publish to pub.dev
@@ -21,6 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dart-lang/setup-dart@v1 # GitHub authenticates to pub.dev via OIDC in this step
+      - uses: flutter-actions/setup-flutter@v2
+        with:
+          channel: stable
+          version: 3.19.0
       - name: Install dependencies
         run: dart pub get
       - name: Publish


### PR DESCRIPTION
[Previous attempts to publish to pub.dev](https://github.com/breez/breez-sdk-flutter/actions/runs/7913697862) failed due to Flutter not being installed on the runner.

I tried running this workflow in my fork of the repo where it successfully ran through: [cnixbtc/breez-sdk-flutter:publish](https://github.com/cnixbtc/breez-sdk-flutter/actions/runs/7942025234/job/21684917055) ✅ 

We need to keep the `dart-lang/setup-dart` step around because this is where the runner authenticates to pub.dev. Even though the dart version will then be overridden in the `flutter-actions/setup-flutter` step.