### PR TITLE
Fix flutter version in pub.dev publishing step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,11 +8,10 @@
 
 name: Publish to pub.dev
 
-# on:
-#   push:
-#     tags:
-#     - 'v[0-9]+.[0-9]+.[0-9]+*'
-on: workflow_dispatch
+on:
+  push:
+    tags:
+    - 'v[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
   publish:
@@ -25,8 +24,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
-      - run: flutter --version
       - name: Install dependencies
         run: dart pub get
       - name: Publish
-        run: dart pub publish --dry-run --skip-validation # --force --skip-validation
+        run: dart pub publish --force --skip-validation


### PR DESCRIPTION
We've [recently](https://github.com/breez/breez-sdk/commit/e438c4e78457e49cbc70f2e1dc6cef344d12034a) bumped our requirements for Flutter/Dart SDK versions (which is a good thing!). The action we were using in the _pub.dev_ publishing workflow somehow didn't fetch the latest (as of now: 3.19.0) Flutter version, though. So the build [failed](https://github.com/breez/breez-sdk-flutter/actions/runs/8153625686).

This PR replaces the action used with one that seems more maintained (2k ⭐ on :octocat:). I did a [test run ](https://github.com/cnixbtc/breez-sdk-flutter/actions/runs/8192682568/job/22404766723)on my fork of this repo and indeed, this time the latest stable Flutter version was installed, and the whole remaining workflow (using `--dry-run`) went through.

<img width="591" alt="Screenshot 2024-03-07 at 19 02 07" src="https://github.com/breez/breez-sdk-flutter/assets/111755602/ea719bd6-4108-4907-b73c-3f02dae3e7ae">

---

In the meantime, I pushed the tag v0.3.2 of this repo manually to _pub.dev_: [breez_sdk 0.3.2](https://pub.dev/packages/breez_sdk). Note that this release doesn't have the readme and changelog updates, but the next one should have (see https://github.com/breez/breez-sdk/pull/820).
